### PR TITLE
Migrate project to TypeScript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-CMD [ "node", "server.js" ] 
+RUN npm run build
+CMD [ "node", "./dist/server.js" ] 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-hyperdev-app",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2498,6 +2498,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true
     },
     "ultron": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "my-hyperdev-app",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "What am I about?",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "node ./dist/server.js",
     "lint-dockerfile": "dockerfilelint Dockerfile",
     "lint-yaml": "eslint . --ext .yml",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "prebuild:test": "rm -rf dist",
+    "build:test": "tsc --project tsconfig.test.json",
+    "postbuild:test": "cp -r ./views ./public ./dist",
+    "prebuild": "rm -rf dist",
+    "build": "tsc --project tsconfig.production.json",
+    "postbuild": "cp -r ./views ./public ./dist"
   },
   "dependencies": {
     "express": "^4.14.0",
@@ -37,6 +43,7 @@
     "dockerfilelint": "^1.8.0",
     "eslint": "^7.12.1",
     "eslint-plugin-yaml": "^0.3.0",
-    "prettier": "^2.1.2"
+    "prettier": "^2.1.2",
+    "typescript": "^4.0.5"
   }
 }

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es5"
+  },
+  "include": ["./*", "./routes/*"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es5"
+  },
+  "include": ["./*"]
+}


### PR DESCRIPTION
`Dockerfile` now builds the `dist` folder, which contains the transpiled files, html files, and css files. 
* To build all files, including test files, use `npm run build:test`.
* To build only the files needed in production, use `npm run build`.
Npm pre- and post- hooks are used to reset the `dist` directory and copy html and css files. Currently, TypeScript is configured to look at JavaScript files, in addition to TypeScript files. In subsequent pull requests, types will be added incrementally to complete the migration from JavaScript to TypeScript.