### PR TITLE
Include test folder.

### DIFF
--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -5,5 +5,5 @@
     "target": "es5",
     "esModuleInterop": true
   },
-  "include": ["./*", "./routes/*"]
+  "include": ["./**/*"]
 }


### PR DESCRIPTION
Prod was down from previous merge. The logs show `Error: ENOENT: no such file or directory, scandir './dist/tests'`. Previously, it was assumed that test files were not necessary in production, but in this project, the tests are part of the deliverable. A better fix is in the pipeline, but currently, prod should behave as expected in the last commit.