### PR TITLE
Implement and write tests for PUT on /api/issues/:project endpoint

### DIFF
--- a/routes/api.ts
+++ b/routes/api.ts
@@ -48,7 +48,7 @@ module.exports = function (app: Application): void {
       try {
         var dbo = await db;
         var saved = await dbo
-          .collection(project)
+          .collection("issue_tracker")
           .insertOne({ ...entry, project_name: project });
         res.json({
           ...entry,
@@ -60,8 +60,33 @@ module.exports = function (app: Application): void {
       }
     })
 
-    .put(function (req: Request, res: Response) {
+    .put(async function (req: Request, res: Response): Promise<void> {
       var project: string = req.params.project;
+      var body = req.body;
+      var _id: string = body._id;
+      delete body._id;
+
+      if (!_id) {
+        res.send("missing required fields");
+        return;
+      }
+      if (Object.keys(body).length === 0) {
+        res.send("no updated field sent");
+        return;
+      }
+      try {
+        var dbo = await db;
+        await dbo
+          .collection("issue_tracker")
+          .updateOne(
+            { _id: ObjectID(_id), project_name: project },
+            { $set: body },
+            { upsert: false }
+          );
+        res.send("successfully updated");
+      } catch (error) {
+        res.send("could not update " + _id);
+      }
     })
 
     .delete(function (req: Request, res: Response) {

--- a/tests/2_functional-tests.ts
+++ b/tests/2_functional-tests.ts
@@ -102,11 +102,81 @@ suite("Functional Tests", function (): void {
   );
 
   suite("PUT /api/issues/{project} => text", function (): void {
-    test("No body", function (done: Mocha.Done): void {});
+    test("No body", function (done: Mocha.Done): void {
+      chai
+        .request(server)
+        .put("/api/issues/test")
+        .send()
+        .end(function (err, res): void {
+          if (err) {
+            done(err);
+          }
+          assert.equal(res.status, 200);
+          assert.equal(res.text, "missing required fields");
+          done();
+        });
+    });
 
-    test("One field to update", function (done: Mocha.Done): void {});
+    test("One field to update", function (done: Mocha.Done): void {
+      chai
+        .request(server)
+        .post("/api/issues/test")
+        .send({
+          issue_title: "Title",
+          issue_text: "text",
+          created_by: "User",
+          assigned_to: "Chai and Mocha",
+          status_text: "In QA",
+        })
+        .then(function (response): void {
+          chai
+            .request(server)
+            .put("/api/issues/test")
+            .send({
+              _id: response.body._id,
+              issue_text: "Updated text",
+            })
+            .end(function (err, res): void {
+              if (err) {
+                done(err);
+              }
+              assert.equal(res.status, 200);
+              assert.equal(res.text, "successfully updated");
+              done();
+            });
+        });
+    });
 
-    test("Multiple fields to update", function (done: Mocha.Done): void {});
+    test("Multiple fields to update", function (done: Mocha.Done): void {
+      chai
+        .request(server)
+        .post("/api/issues/test")
+        .send({
+          issue_title: "Title",
+          issue_text: "text",
+          created_by: "User",
+          assigned_to: "Chai and Mocha",
+          status_text: "In QA",
+        })
+        .then(function (response): void {
+          chai
+            .request(server)
+            .put("/api/issues/test")
+            .send({
+              _id: response.body._id,
+              issue_text: "Updated text",
+              assigned_to: "User2",
+            })
+            .end(function (err, res): void {
+              if (err) {
+                done(err);
+              }
+              assert.equal(res.status, 200);
+              assert.equal(res.text, "successfully updated");
+              done();
+            });
+        });
+    });
   });
 
   suite(


### PR DESCRIPTION
The first test "No body" is read as a request with an empty body. Handling of a PUT request to the endpoint without the required `_id` field was not specified, so the message returned is now `missing required fields`.

Currently, there are nested promises in the tests. There is likely a better way of organizing these async calls.