### PR TITLE
Revert "Install dependencies only during build for production"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14.15.0
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm install
 COPY . .
 RUN npm run build
 CMD [ "node", "./dist/server.js" ] 


### PR DESCRIPTION
Reverts choilmto/boilerplate-project-issuetracker#26

`devDependencies` needed for build process.